### PR TITLE
Thread.prototype.consult accepts both a filename or prolog predicates

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -2163,7 +2163,9 @@
 			// file (node.js)
 			} else if( nodejs_flag ) {
 				var fs = require("fs");
-				string = fs.readFileSync( program ).toString();
+				const isFile = fs.existsSync(program);
+				if(isFile) string = fs.readFileSync( program ).toString();
+				else string = program;
 			// http request
 			} else {
 				try {


### PR DESCRIPTION
As described in [this issue](https://github.com/tau-prolog/tau-prolog/issues/101), the `consult` method has changed in a way that related tests are no longer in sync with its behaviour. 

The following PR provides a fix that add polymorphism to the `Thread.prototype.consult` method in order to allow both filename or literal predicates when using in nodejs. 