### PR TITLE
Fix nodejs detection

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -2779,7 +2779,7 @@
 
 	// NODEJS
 
-	var nodejs_flag = typeof module !== 'undefined' && module.exports !== undefined;
+	var nodejs_flag = typeof process !== 'undefined' && !process.browser
 
 	var nodejs_arguments = nodejs_flag ?
 		arrayToList( map(process.argv.slice(1), function(arg) { return new Term( arg ); })) :


### PR DESCRIPTION
Tau currently thinks it's running in nodejs when actually running in a bundle created by e.g. browserify. This way of detection is more accurate, which should fix #114