### PR TITLE
Fix current_predicate/1 failure instead of exception

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -5521,6 +5521,8 @@
 				thread.throw_error(pl.error.type( "atom", indicator.args[0], atom.indicator));
 			} else if(!pl.type.is_variable(indicator) && !pl.type.is_variable(indicator.args[1]) && !pl.type.is_integer(indicator.args[1])) {
 				thread.throw_error(pl.error.type("integer", indicator.args[1], atom.indicator));
+			} else if(!pl.type.is_variable(indicator) && pl.type.is_integer(indicator.args[1]) && indicator.args[1] < 0) {
+				thread.throw_error(pl.error.domain("not_less_than_zero", indicator.args[1], atom.indicator));
 			} else {
 				var states = [];
 				var get_module = thread.session.modules[module_id];

--- a/modules/core.js
+++ b/modules/core.js
@@ -5521,7 +5521,7 @@
 				thread.throw_error(pl.error.type( "atom", indicator.args[0], atom.indicator));
 			} else if(!pl.type.is_variable(indicator) && !pl.type.is_variable(indicator.args[1]) && !pl.type.is_integer(indicator.args[1])) {
 				thread.throw_error(pl.error.type("integer", indicator.args[1], atom.indicator));
-			} else if(!pl.type.is_variable(indicator) && pl.type.is_integer(indicator.args[1]) && indicator.args[1] < 0) {
+			} else if(!pl.type.is_variable(indicator) && pl.type.is_integer(indicator.args[1]) && indicator.args[1].value < 0) {
 				thread.throw_error(pl.error.domain("not_less_than_zero", indicator.args[1], atom.indicator));
 			} else {
 				var states = [];


### PR DESCRIPTION
When the argument arity is an integer less than zero, the standard dictates a `domain_error(not_less_than_zero,N)` exception.