### PR TITLE
Fix compare/3 predicate order argument domain error

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -6553,7 +6553,7 @@
 			if( !pl.type.is_variable( order ) && !pl.type.is_atom( order ) ) {
 				thread.throw_error( pl.error.type( "atom", order, atom.indicator ) );
 			} else if( pl.type.is_atom( order ) && ["<", ">", "="].indexOf( order.id ) === -1 ) {
-				thread.throw_error( pl.type.domain( "order", order, atom.indicator ) );
+				thread.throw_error( pl.error.domain( "order", order, atom.indicator ) );
 			} else {
 				var compare = pl.compare( left, right );
 				compare = compare === 0 ? "=" : (compare === -1 ? "<" : ">");


### PR DESCRIPTION
This PR fixes a JavaScript crash when a `domain_error(order,Term)` exception is expected.