### PR TITLE
Add missing error checking case to the =../2 predicate

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -5371,6 +5371,8 @@
 				thread.throw_error( pl.error.instantiation( atom.indicator ) );
 			} else if( !pl.type.is_fully_list( atom.args[1] ) ) {
 				thread.throw_error( pl.error.type( "list", atom.args[1], atom.indicator ) );
+			} else if( pl.type.is_variable( atom.args[0] ) && atom.args[1] == "[]" ) {
+				thread.throw_error( pl.error.domain( "non_empty_list", atom.args[1], atom.indicator ) );
 			} else if( !pl.type.is_variable( atom.args[0] ) ) {
 				if( pl.type.is_atomic( atom.args[0] ) ) {
 					list = new Term( ".", [atom.args[0], new Term( "[]" )] );

--- a/modules/core.js
+++ b/modules/core.js
@@ -5371,7 +5371,7 @@
 				thread.throw_error( pl.error.instantiation( atom.indicator ) );
 			} else if( !pl.type.is_fully_list( atom.args[1] ) ) {
 				thread.throw_error( pl.error.type( "list", atom.args[1], atom.indicator ) );
-			} else if( pl.type.is_variable( atom.args[0] ) && atom.args[1] == "[]" ) {
+			} else if( pl.type.is_variable( atom.args[0] ) && pl.type.is_empty_list( atom.args[1] ) ) {
 				thread.throw_error( pl.error.domain( "non_empty_list", atom.args[1], atom.indicator ) );
 			} else if( !pl.type.is_variable( atom.args[0] ) ) {
 				if( pl.type.is_atomic( atom.args[0] ) ) {


### PR DESCRIPTION
The case where the first argument is a variable and the second argument is an empty list is required to throw a `domain_error(non_empty_list,[])` exception.