### PR TITLE
fixed existence_error procedure exception when running the fruit.js n…

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -2522,16 +2522,18 @@
 			if(!success && options.file && this.get_flag("nodejs").indicator === "true/0") {
 				var fs = require("fs");
 				var thread = this;
-				fs.readFile(program, function(error, data) {
-					if(error) {
-						options.file = false;
-						thread.consult(program, options);
-					} else {
-						parseProgram(thread, data.toString(), options);
-					}
-				});
+
+				if(fs.existsSync(program)) {
+					var data = fs.readFileSync(program, 'utf-8');
+					parseProgram(thread, data, options);
+
+				} else {
+					options.file = false;
+					thread.consult(program, options);
+				}
 				return;
 			}
+
 			// http request
 			if(!success && this.get_flag("nodejs").indicator === "false/0" && options.url && program !== "" && !(/\s/.test(program))) {
 				try {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "./modules/core.js",
 	"scripts": {
 		"example:fruit": "node examples/nodejs/fruit",
-		"test": "node_modules/.bin/qunit test"
+		"test": "./node_modules/.bin/qunit test"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
…odejs example

The problem was, that before the async function fs.readFile was used, because when we called session.query in the 
fruit.js example, the thread.session.modules.user.rules was empty and we get an  
uncaught exception: error(existence_error(procedure, /(fruits_in, 2)), /(top_level, 0))

The qunit unit tests now run again with nodejs too.
