### PR TITLE
Fix meta_predicate/1 directive crash

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -4264,7 +4264,8 @@
 			},
 
 			// meta_predicate/1
-			"meta_predicate/1": function(thread, atom) {
+			"meta_predicate/1": function(thread, atom, options) {
+				var options = options === undefined ? {} : options;
 				var head = atom.args[0];
 				if( pl.type.is_variable(head) ) {
 					thread.throw_warning(pl.error.instantiation(atom.indicator));


### PR DESCRIPTION
This pull request fixes the following crash:

```text
?- {tester}.
/Users/pmoura/Documents/Logtalk/tp/node_modules/tau-prolog/modules/core.js:4281
					thread.session.modules[options.context_module].meta_predicates[head.indicator] = head;
					                       ^

ReferenceError: options is not defined
    at Object.meta_predicate/1 (/Users/pmoura/Documents/Logtalk/tp/node_modules/tau-prolog/modules/core.js:4281:29)
    at Thread.run_directive (/Users/pmoura/Documents/Logtalk/tp/node_modules/tau-prolog/modules/core.js:2521:45)
    at parseProgramExpansion (/Users/pmoura/Documents/Logtalk/tp/node_modules/tau-prolog/modules/core.js:1202:24)
    at parseProgram (/Users/pmoura/Documents/Logtalk/tp/node_modules/tau-prolog/modules/core.js:1101:18)
    at /Users/pmoura/Documents/Logtalk/tp/node_modules/tau-prolog/modules/core.js:2641:7
    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:63:3)
```
