### PR TITLE
WIP: Add walltime statistics key

### DIFF
--- a/modules/statistics.js
+++ b/modules/statistics.js
@@ -124,7 +124,12 @@ var pl;
 		
 		// Total cpu time
 		cputime: function( thread ) {
-			return new pl.type.Num( thread.cpu_time , false );
+			return new pl.type.Num( thread.cpu_time, false );
+		},
+		
+		// wall time
+		walltime: function( thread ) {
+			return new pl.type.Num( Date.now(), false );
 		},
 		
 		// Time stamp when thread was started


### PR DESCRIPTION
The following works:

```text
?- statistics.
% Tau Prolog statistics
%%% atoms: 8365949
%%% clauses: 4418
%%% cputime: 25
%%% walltime: 1599415137613
%%% epoch: 1599412929221
%%% inferences: 44
%%% modules: NaN
%%% predicates: 1179
%%% runtime: [25,2]
%%% threads: 23true.

?- statistics(K, V).
K = atoms, V = 8365331 ;
;
K = clauses, V = 4418 ;
;
K = cputime, V = 22 ;
;
K = walltime, V = 1599414728216 ;
;
K = epoch, V = 1599412929221 ;
...
```

But:

```text
?- statistics(waltime, T).
uncaught exception: error(domain_error(statistics_key,waltime),statistics/2)
```

What am I missing?