### PR TITLE
Add promise interface to consult, query, and answer

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -2711,7 +2711,7 @@
 			return new Promise((resolve, reject) => {
 				var promiseOpts = Object.assign({}, opts, {
 					success: resolve,
-					error: (term) => reject({ type: 'consult_throw', term })
+					error: (term) => reject(new pl.errors.TermThrow('consult_throw', term)),
 				})
 				parseProgram(this, string, promiseOpts);
 			})
@@ -2737,7 +2737,7 @@
 			return new Promise((resolve, reject) => {
 				var promiseOpts = Object.assign({}, options, {
 					success: resolve,
-					error: (term) => reject({ type: 'query_throw', term }),
+					error: (term) => reject(new pl.errors.TermThrow('query_throw', term)),
 				});
 				parseQuery(this, string, promiseOpts);
 			})
@@ -3030,8 +3030,8 @@
 				this.__calls.push({
 					success: resolve,
 					fail: () => resolve(false),
-					error: (term) => reject({ type: 'answer_throw', term }),
-					limit: () => reject({ type: 'answer_limit' }),
+					error: (term) => reject(new pl.errors.TermThrow('answer_throw', term)),
+					limit: () => reject(new pl.errors.TermThrow('answer_limit')),
 				})
 				if( this.__calls.length > 1 ) {
 					return;
@@ -3663,6 +3663,17 @@
 			}
 		},
 		
+		// Errors
+		errors: {
+			TermThrow: class TermThrow extends Error {
+				constructor(type, term) {
+					super(`Thrown term (${type}): ${JSON.stringify(term.toJavaScript())}`)
+					this.type = type
+					this.term = term
+				}
+			}
+		},
+
 		// Types
 		type: {
 			


### PR DESCRIPTION
Solution for one point in https://github.com/tau-prolog/tau-prolog/pull/116#issuecomment-614032569

This adds a promise interface to `session.query` and `session.answer`. This allows the current readme example:

```js
session.consult(program, {
    success: function() {
        // Query
        session.query(goal, {
            success: function(goal) {
                // Answers
                session.answer({
                    success: function(answer) { /* Answer */ },
                    error:   function(err) { /* Uncaught error */ },
                    fail:    function() { /* Fail */ },
                    limit:   function() { /* Limit exceeded */ }
                })
            },
            error: function(err) { /* Error parsing goal */ }
        });
    },
    error: function(err) { /* Error parsing program */ }
});
```

to be written like this:

```js
async function example() {
  await session.consult(program)
  await session.query(goal)
  const answer = await session.answer()
  answer  //=> Substitution, or false if no more answers
}
```

Handling errors look like this (please advise if this doesn't cover all cases):

```js
example().catch(error => {
  error instanceof pl.errors.TermThrow  //=> true
  error.type  //=> 'consult_throw', 'query_throw', 'answer_throw', or 'answer_limit'
  error.term  //=> The thrown Term, if any
})
```

I also tried to keep things backwards compatible so that the original example still works.

Let me know what needs to be changed, or feel free to change/adopt the code to your liking. Thanks!