### PR TITLE
Fix findall/4 predicate type-checking of the tail argument

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -5635,6 +5635,8 @@
 				thread.throw_error( pl.error.type( "callable", goal, atom.indicator ) );
 			} else if( !pl.type.is_variable( instances ) && !pl.type.is_list( instances ) ) {
 				thread.throw_error( pl.error.type( "list", instances, atom.indicator ) );
+			} else if( !pl.type.is_variable( tail ) && !pl.type.is_list( tail ) ) {
+				thread.throw_error( pl.error.type( "list", tail, atom.indicator ) );
 			} else {
 				if(!pl.type.is_variable(instances)) {
 					var pointer = instances;
@@ -5642,6 +5644,15 @@
 						pointer = pointer.args[1];
 					if(!pl.type.is_variable(pointer) && !pl.type.is_empty_list(pointer)) {
 						thread.throw_error(pl.error.type("list", instances, atom.indicator));
+						return;
+					}
+				}
+				if(!pl.type.is_variable(tail)) {
+					var pointer_t = tail;
+					while(pl.type.is_term(pointer_t) && pointer_t.indicator === "./2")
+						pointer_t = pointer_t.args[1];
+					if(!pl.type.is_variable(pointer_t) && !pl.type.is_empty_list(pointer_t)) {
+						thread.throw_error(pl.error.type("list", tail, atom.indicator));
 						return;
 					}
 				}


### PR DESCRIPTION
This pull request fixes the two single failures in the Logtalk standards compliance suite tests for the de facto standard `findall/4` predicate.