### PR TITLE
Fix crashes in the get_char/2, get_code/2, peek_char/2, and read_term/3 predicates when eof_action is set to eof_code

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -7999,6 +7999,9 @@
 				if( stream2.position === "end_of_stream" ) {
 					stream_char = "end_of_file";
 					stream2.position = "past_end_of_stream";
+				} else if( stream2.position === "past_end_of_stream" ) {
+					stream_char = "end_of_file";
+					stream2.position = "past_end_of_stream";
 				} else {
 					stream_char = stream2.stream.get( 1, stream2.position );
 					if( stream_char === null ) {
@@ -8055,6 +8058,9 @@
 				if( stream2.position === "end_of_stream" ) {
 					stream_code = -1;
 					stream2.position = "past_end_of_stream";
+				} else if( stream2.position === "past_end_of_stream" ) {
+					stream_code = -1;
+					stream2.position = "past_end_of_stream";
 				} else {
 					stream_code = stream2.stream.get( 1, stream2.position );
 					if( stream_code === null ) {
@@ -8108,6 +8114,9 @@
 			} else {
 				var stream_char;
 				if( stream2.position === "end_of_stream" ) {
+					stream_char = "end_of_file";
+					stream2.position = "past_end_of_stream";
+				} else if( stream2.position === "past_end_of_stream" ) {
 					stream_char = "end_of_file";
 					stream2.position = "past_end_of_stream";
 				} else {
@@ -8433,6 +8442,12 @@
 				thread.throw_error( pl.error.permission( "input", "binary_stream", stream, atom.indicator ) );
 			} else if( stream2.position === "past_end_of_stream" && stream2.eof_action === "error" ) {
 				thread.throw_error( pl.error.permission( "input", "past_end_of_stream", stream, atom.indicator ) );
+			} else if( stream2.position === "past_end_of_stream" && stream2.eof_action === "eof_code" ) {
+				expr = {
+					value: new Term("end_of_file", []),
+					type: SUCCESS,
+					len: -1
+				};
 			} else {
 				// Get options
 				var obj_options = {};


### PR DESCRIPTION
With these fixes, the Logtalk bundled tests for these predicates no longer crash. Moreover, all tests for the `get_char/2`, `get_code/2` and `peek_char/2` predicates pass. In the case of the `read_term/3` predicate, there are 7 failed tests. Besides solving the crash, I expected the patch to fix the following test:

```logtalk
test(lgt_read_term_3_25, true(Term == end_of_file)) :-
	^^set_text_input(st_o, '', [eof_action(eof_code)]),
	get_code(st_o, _),
	{read_term(st_o, Term, [])}.
```

But it still fails. Anyway, the main point of this pull request is to fix these four crashes. These are also the only crashes when running all the Logtalk standards compliance tests in its latest git version.