### PR TITLE
Fix missing instantiation errors in the atomic_list_concat/2-3 predicates

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -7243,41 +7243,36 @@
 				thread.throw_error( pl.error.instantiation( atom.indicator ) );
 			} else if( !pl.type.is_variable( list ) && !pl.type.is_list( list ) ) {
 				thread.throw_error( pl.error.type( "list", list, atom.indicator ) );
+			} else if( !pl.type.is_atom( separator ) && !pl.type.is_number( separator ) ) {
+				thread.throw_error( pl.error.type( "atomic", separator, atom.indicator ) );
 			} else if( !pl.type.is_variable( concat ) && !pl.type.is_atom( concat ) ) {
 				thread.throw_error( pl.error.type( "atom", concat, atom.indicator ) );
 			} else {
-				if( !pl.type.is_variable( concat ) ) {
-					var atomic = arrayToList( map(
-						concat.id.split( separator.id ),
-						function( id ) {
-							return new Term( id, [] );
-						}
-					) );
-					thread.prepend( [new State( point.goal.replace( new Term( "=", [atomic, list] ) ), point.substitution, point )] );
-				} else {
-					var id = "";
-					var pointer = list;
-					while( pl.type.is_term( pointer ) && pointer.indicator === "./2" ) {
-						if( !pl.type.is_atom( pointer.args[0] ) && !pl.type.is_number( pointer.args[0] ) ) {
-							thread.throw_error( pl.error.type( "atomic", pointer.args[0], atom.indicator ) );
-							return;
-						}
-						if( id !== "" )
-							id += separator.id;
-						if( pl.type.is_atom( pointer.args[0] ) )
-							id += pointer.args[0].id;
-						else
-							id += "" + pointer.args[0].value;
-						pointer = pointer.args[1];
-					}
-					id = new Term( id, [] );
-					if( pl.type.is_variable( pointer ) ) {
+				var id = "";
+				var pointer = list;
+				while( pl.type.is_term( pointer ) && pointer.indicator === "./2" ) {
+					if( pl.type.is_variable( pointer.args[0] ) ) {
 						thread.throw_error( pl.error.instantiation( atom.indicator ) );
-					} else if( !pl.type.is_term( pointer ) || pointer.indicator !== "[]/0" ) {
-						thread.throw_error( pl.error.type( "list", list, atom.indicator ) );
-					} else {
-						thread.prepend( [new State( point.goal.replace( new Term( "=", [id, concat] ) ), point.substitution, point )] );
+						return;
+					} else if( !pl.type.is_atom( pointer.args[0] ) && !pl.type.is_number( pointer.args[0] ) ) {
+						thread.throw_error( pl.error.type( "atomic", pointer.args[0], atom.indicator ) );
+						return;
 					}
+					if( id !== "" )
+						id += separator.id;
+					if( pl.type.is_atom( pointer.args[0] ) )
+						id += pointer.args[0].id;
+					else
+						id += "" + pointer.args[0].value;
+					pointer = pointer.args[1];
+				}
+				id = new Term( id, [] );
+				if( pl.type.is_variable( pointer ) ) {
+					thread.throw_error( pl.error.instantiation( atom.indicator ) );
+				} else if( !pl.type.is_term( pointer ) || pointer.indicator !== "[]/0" ) {
+					thread.throw_error( pl.error.type( "list", list, atom.indicator ) );
+				} else {
+					thread.prepend( [new State( point.goal.replace( new Term( "=", [id, concat] ) ), point.substitution, point )] );
 				}
 			}
 		},


### PR DESCRIPTION
The crashes in the Logtalk tests sets for the `atomic_list_concat/2-3` predicates is due to the use of QuickCheck in the first test. Skipping these tests, expose the bugs fixed in this pull request. With it, all tests for the `atomic_list_concat/3` predicate pass and only two tests fail for the `atomic_list_concat/2` predicate:

```text
!     atomic_list_concat_2_long_empty_list: failure (in 0.0010000000000000009 seconds)
!       test assertion failed: 'a1b+2[]c-3.5'=='a1b+2.0[]c-3.5'
!       in file /Users/pmoura/Documents/Logtalk/logtalk3/tests/prolog/predicates/atomic_list_concat_2/tests.lgt between lines 39-42
!     atomic_list_concat_2_long_empty_curly: failure (in 0.0020000000000000018 seconds)
!       test assertion failed: 'a1b+2{}c-3.5'=='a1b+2.0{}c-3.5'
!       in file /Users/pmoura/Documents/Logtalk/logtalk3/tests/prolog/predicates/atomic_list_concat_2/tests.lgt between lines 42-45
```

The bug in these two tests must be fixed elsewhere.